### PR TITLE
update COBRAsolver to add weighted constraints

### DIFF
--- a/src/main/java/org/simulator/fba/COBRAsolver.java
+++ b/src/main/java/org/simulator/fba/COBRAsolver.java
@@ -238,6 +238,7 @@ public class COBRAsolver {
 		// Add weighted constraints equations for each reaction.
 		for (Species species : model.getListOfSpecies()) {
 			double[] weights = new double[reaction2Index.size()];
+			int numberOfReactions = 0;
 			
 			if (!species2Reaction.containsKey(species.getId())) {
 				logger.warning(MessageFormat.format(
@@ -246,10 +247,13 @@ public class COBRAsolver {
 			} else {
 				for (Pair<String, Double> pair : species2Reaction.get(species.getId())) {
 					weights[reaction2Index.get(pair.getKey())] = pair.getValue();
+					numberOfReactions++;
 				}
 			}
 			
-			problem.addConstraint(new LinearEqualsConstraint(weights, 0.0, "cnstrt_" + species.getId()));
+			if (numberOfReactions > 1){
+				problem.addConstraint(new LinearEqualsConstraint(weights, 0.0, "cnstrt_" + species.getId()));
+			}
 		}	
 	}
 

--- a/src/main/java/org/simulator/fba/COBRAsolver.java
+++ b/src/main/java/org/simulator/fba/COBRAsolver.java
@@ -238,7 +238,6 @@ public class COBRAsolver {
 		// Add weighted constraints equations for each reaction.
 		for (Species species : model.getListOfSpecies()) {
 			double[] weights = new double[reaction2Index.size()];
-			int numberOfReactions = 0;
 			
 			if (!species2Reaction.containsKey(species.getId())) {
 				logger.warning(MessageFormat.format(
@@ -247,11 +246,10 @@ public class COBRAsolver {
 			} else {
 				for (Pair<String, Double> pair : species2Reaction.get(species.getId())) {
 					weights[reaction2Index.get(pair.getKey())] = pair.getValue();
-					numberOfReactions++;
 				}
 			}
 			
-			if (numberOfReactions > 1){
+			if (species2Reaction.get(species.getId()).size() > 1){
 				problem.addConstraint(new LinearEqualsConstraint(weights, 0.0, "cnstrt_" + species.getId()));
 			}
 		}	


### PR DESCRIPTION
In COBRAsolver class, when any reactant is just involved in a single reaction, then there should be no weight constraint for it. 

This pull request solves this issue by adding the condition to add the weight constraint when the reactant is involved in more than one reaction.