### PR TITLE
fixed issue in OMEXArchive

### DIFF
--- a/src/main/java/org/simulator/examples/OMEXExample.java
+++ b/src/main/java/org/simulator/examples/OMEXExample.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.fail;
 import java.io.File;
 import java.io.IOException;
 import java.text.ParseException;
+import java.util.List;
 import java.util.Map;
 
 import org.jdom2.JDOMException;
@@ -39,6 +40,7 @@ import org.jlibsedml.SEDMLDocument;
 import org.jlibsedml.SedML;
 import org.jlibsedml.XMLException;
 import org.jlibsedml.execution.IRawSedmlSimulationResults;
+import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.simulator.omex.OMEXArchive;
 import org.simulator.sedml.MultTableSEDMLWrapper;
 import org.simulator.sedml.SedMLSBMLSimulatorExecutor;
@@ -53,7 +55,7 @@ import de.unirostock.sems.cbarchive.CombineArchiveException;
 public class OMEXExample {
 	
 	public static void main(String[] args) throws IOException, ParseException, CombineArchiveException,
-	JDOMException, XMLException {
+			JDOMException, XMLException, OWLOntologyCreationException {
 		String file = args[0];
 		if (file.isEmpty()) {
 			LOGGER.warn("Please enter a valid omex file as argument.");
@@ -68,15 +70,17 @@ public class OMEXExample {
 			SedML sedml = doc.getSedMLModel();
 
 			Output wanted = sedml.getOutputs().get(0);
-			SedMLSBMLSimulatorExecutor exe = new SedMLSBMLSimulatorExecutor(sedml, wanted, null);
+			SedMLSBMLSimulatorExecutor exe = new SedMLSBMLSimulatorExecutor(sedml, wanted, archive.getSEDMLDescp().getParentFile().getAbsolutePath());
 
-			Map<AbstractTask, IRawSedmlSimulationResults> res = exe.runSimulations();
+			Map<AbstractTask, List<IRawSedmlSimulationResults>> res = exe.run();
 			if ((res == null) || res.isEmpty() || !exe.isExecuted()) {
-				fail ("Simulatation failed: " + exe.getFailureMessages().get(0).getMessage());
+				fail ("Simulation failed: " + exe.getFailureMessages().get(0).getMessage());
 			}
 			
-			for (IRawSedmlSimulationResults re: res.values()) {
-				assertTrue(re instanceof MultTableSEDMLWrapper);
+			for (List<IRawSedmlSimulationResults> re_list: res.values()) {
+				for (IRawSedmlSimulationResults re: re_list){
+					assertTrue(re instanceof MultTableSEDMLWrapper);
+				}
 			}
 		}
 		

--- a/src/main/java/org/simulator/omex/OMEXArchive.java
+++ b/src/main/java/org/simulator/omex/OMEXArchive.java
@@ -46,7 +46,7 @@ public class OMEXArchive {
 	private Map<String, ArchiveEntry> entryMap;
 	private boolean has_models;
 	private boolean has_sim_descp;
-	private File sed_ml;
+	private File sed_ml, sb_ml;
 
 	public OMEXArchive(File zipFile) throws IOException, ParseException, CombineArchiveException, JDOMException{
 		entryMap = new HashMap<String, ArchiveEntry>();
@@ -55,15 +55,23 @@ public class OMEXArchive {
 		
 		archive = new CombineArchive(zipFile);
 
+		File parent = new File(System.getProperty("java.io.tmpdir"));
+
 		// iterate over all entries in the archive and create a Map
 		for (ArchiveEntry entry : archive.getEntries())
 		{
 			entryMap.put(entry.getFilePath(), entry);
-			if(entry.getFormat().toString().contains("SBML") || entry.getFormat().toString().contains("sbml"))
+			if(entry.getFormat().toString().contains("SBML") || entry.getFormat().toString().contains("sbml")){
 				has_models = true;
+
+				File sb_ml_file = new File(parent, entry.getFileName());
+				sb_ml = entry.extractFile(sb_ml_file);
+			}
 			if(entry.getFormat().toString().contains("SED-ML") || entry.getFormat().toString().contains("sed-ml")) {
 				has_sim_descp = true;
-				sed_ml = entry.getFile();
+
+				File sed_ml_file = new File(parent, entry.getFileName());
+				sed_ml = entry.extractFile(sed_ml_file);
 			}
 		}
 


### PR DESCRIPTION
@draeger 
This PR fixes the issue occured while simulating the OMEX test file (present at `src/test/resources/omex`) using `OMEXExample.java`
The error was 
`Exception in thread "main" java.lang.AssertionError: Simulatation failed:  The model could not be resolved from its source reference. (Using uri: ./BIOMD0000000012.xml)
	at org.junit.Assert.fail(Assert.java:88)
	at org.simulator.examples.OMEXExample.main(OMEXExample.java:75)`

- The issue was that while running a temporarily created SED-ML file for simulation, the source file i.e. `BIOMD0000000012.xml` should also be present in the same directory. So, this PR also creates the source file in the same location where temporary SED-ML file is created.

- Also, the deprecated getFile() method in OMEXArchive is replaced with the extractFile() method.

- This PR also updates the `OMEXExample.java` and solves the SED-ML file similar to the how simple SED-ML file is solved (as in `SEDMLExample.java`).