### PR TITLE
Fewer BigDecimal conversions

### DIFF
--- a/src/main/java/org/simulator/math/odes/AbstractDESSolver.java
+++ b/src/main/java/org/simulator/math/odes/AbstractDESSolver.java
@@ -391,7 +391,7 @@ public abstract class AbstractDESSolver
     Mathematics.vvAdd(yPrev, change, yTemp);
     checkNonNegativity(yTemp);
     if (increase) {
-      t = BigDecimal.valueOf(stepSize).add(BigDecimal.valueOf(t)).doubleValue();
+      t += stepSize;
     }
     if (!steadyState) {
       processEventsAndRules(false, DES, t, previousTime, yTemp);
@@ -528,8 +528,7 @@ public abstract class AbstractDESSolver
     }
     double[] timePoints = new double[numSteps];
     for (int i = 0; i < timePoints.length; i++) {
-      timePoints[i] = BigDecimal.valueOf(timeBegin)
-          .add(BigDecimal.valueOf(i).multiply(BigDecimal.valueOf(stepSize))).doubleValue();
+      timePoints[i] = timeBegin + i * stepSize;
     }
     return initResultMatrix(DES, initialValues, timePoints);
   }
@@ -904,7 +903,7 @@ public abstract class AbstractDESSolver
           System.arraycopy(yPrev, 0, result[0], 0, yPrev.length);
         }
       }
-      h = BigDecimal.valueOf(timePoints[i]).subtract(BigDecimal.valueOf(t)).doubleValue();
+      h = timePoints[i] - t;
       if (h > 1E-14) {
         System.arraycopy(yTemp, 0, yPrev, 0, yTemp.length);
         t = computeNextState(DES, t, h, yTemp, change, yTemp, true, false);
@@ -992,9 +991,9 @@ public abstract class AbstractDESSolver
         computeChange(DES, yTemp, t, h, change, false);
         checkSolution(change, yTemp);
         Mathematics.vvAdd(yTemp, change, yTemp);
-        t = BigDecimal.valueOf(h).add(BigDecimal.valueOf(t)).doubleValue();
+        t += h;
       }
-      h = BigDecimal.valueOf(timePoints[i]).subtract(BigDecimal.valueOf(t)).doubleValue();
+      h = timePoints[i] - t;
       if (h > 1E-14d) {
         computeChange(DES, yTemp, t, h, change, false);
         checkSolution(change);

--- a/src/main/java/org/simulator/math/odes/AbstractDESSolver.java
+++ b/src/main/java/org/simulator/math/odes/AbstractDESSolver.java
@@ -25,7 +25,6 @@ package org.simulator.math.odes;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/src/main/java/org/simulator/math/odes/RosenbrockSolver.java
+++ b/src/main/java/org/simulator/math/odes/RosenbrockSolver.java
@@ -264,6 +264,17 @@ public class RosenbrockSolver extends AdaptiveStepsizeIntegrator {
     JAC = new double[numEqn][numEqn];
     FAC = new double[numEqn][numEqn];
     I = new double[numEqn][numEqn];
+
+    for (int i = 0; i < numEqn; i++) {
+      for (int j = 0; j < numEqn; j++) {
+        if (i == j) {
+          I[i][j] = 1;
+        } else {
+          I[i][j] = 0;
+        }
+      }
+    }
+
     ignoreNaN = new boolean[numEqn];
   }
 
@@ -294,15 +305,6 @@ public class RosenbrockSolver extends AdaptiveStepsizeIntegrator {
       DES.computeDerivatives(t, yb, g2);
       for (int q = 0; q < numEqn; q++) {
         JAC[q][j] = (-3 * g0[q] + 4 * g1[q] - g2[q]) / (2 * h);
-      }
-    }
-    for (int i = 0; i < numEqn; i++) {
-      for (int j = 0; j < numEqn; j++) {
-        if (i == j) {
-          I[i][j] = 1;
-        } else {
-          I[i][j] = 0;
-        }
       }
     }
     for (int i = 0; i < numEqn; i++) {
@@ -440,8 +442,7 @@ public class RosenbrockSolver extends AdaptiveStepsizeIntegrator {
         hasDerivatives = false;
       }
     }
-    double timeEnd = BigDecimal.valueOf(time).add(BigDecimal.valueOf(currentStepSize))
-        .doubleValue();
+    double timeEnd = time + currentStepSize;
     try {
       double localError = 0;
       int solutionIndex = 0;
@@ -475,11 +476,7 @@ public class RosenbrockSolver extends AdaptiveStepsizeIntegrator {
         System.arraycopy(y2, 0, y, 0, y.length);
       }
       for (int i = 0; i != y.length; i++) {
-        if (Double.isInfinite(y[i]) || (Double.isNaN(y[i]))) {
-          ignoreNaN[i] = true;
-        } else {
-          ignoreNaN[i] = false;
-        }
+        ignoreNaN[i] = !Double.isFinite(y[i]);
       }
 
       // add the initial conditions to the solution matrix and let all
@@ -541,7 +538,7 @@ public class RosenbrockSolver extends AdaptiveStepsizeIntegrator {
           System.arraycopy(y, 0, oldY, 0, numEqn);
           System.arraycopy(yTemp, 0, y, 0, numEqn);
           boolean changed = false;
-          double newTime = BigDecimal.valueOf(t).add(BigDecimal.valueOf(h)).doubleValue();
+          double newTime = t + h;
           if ((DES instanceof EventDESystem) && (!steadyState)) {
             EventDESystem EDES = (EventDESystem) DES;
             if ((EDES.getEventCount() > 0) || (EDES.getRuleCount() > 0)) {

--- a/src/main/java/org/simulator/math/odes/RosenbrockSolver.java
+++ b/src/main/java/org/simulator/math/odes/RosenbrockSolver.java
@@ -24,8 +24,6 @@
  */
 package org.simulator.math.odes;
 
-import java.math.BigDecimal;
-
 import org.apache.commons.math.ode.DerivativeException;
 import org.simulator.math.Mathematics;
 import org.simulator.math.MatrixOperations;


### PR DESCRIPTION
I took a look at the tests with [`perf`](https://perf.wiki.kernel.org/index.php/Main_Page) and saw that a bunch of time was spent in `BigDecimal` conversions. At least those in the hot loop seem unnecessary, so I removed them.