### PR TITLE
Match the version of JSBML that we have in maven central.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,8 +9,8 @@ mvn clean install -DskipTests
 
 The tests require additional resources which have to be downloaded. These include the [sbml-testsuite](https://github.com/sbmlteam/sbml-test-suite) and the [BiGG models](https://github.com/matthiaskoenig/bigg-models-fba).
 ```
-source ./src/test/scripts/download_bigg_models.sh
-source ./src/test/scripts/download_sbml-test-suite.sh
+bash ./src/test/scripts/download_bigg_models.sh
+bash ./src/test/scripts/download_sbml-test-suite.sh
 ```
 which then can be run as part of the build step
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -399,7 +399,7 @@
     <dependency>
       <groupId>org.sbml.jsbml</groupId>
       <artifactId>jsbml</artifactId>
-      <version>1.6.1-SNAPSHOT</version>
+      <version>1.6.1</version>
     </dependency>
     <dependency>
       <groupId>org.jdom</groupId>


### PR DESCRIPTION
Match the version of JSBML (1.6.1) located at maven central. Also, the INSTALL.md example assumes the bash user, so it has been changed to work with other shell users (zsh, etc.).