### PR TITLE
Add support for RK2 method and minor improvements in SBMLTestSuiteRunnerWrapper and RK4 method

### DIFF
--- a/src/main/java/org/simulator/math/odes/RungeKutta_EventSolver.java
+++ b/src/main/java/org/simulator/math/odes/RungeKutta_EventSolver.java
@@ -96,26 +96,36 @@ public class RungeKutta_EventSolver extends AbstractDESSolver {
       kVals = new double[4][dim];
       kHelp = new double[dim];
     }
-    // k0
+
+    double halfStep = h * 0.5;
+    double tMid = t + halfStep;
+    double tEnd = t + h;
+
+    // k0 = h * f(t, yTemp)
     DES.computeDerivatives(t, yTemp, kVals[0]);
     Mathematics.svMult(h, kVals[0], kVals[0]);
-    // k1
+
+    // k1 = h * f(t + h/2, y + k0/2)
     Mathematics.svvAddScaled(0.5, kVals[0], yTemp, kHelp);
-    DES.computeDerivatives(t + h / 2, kHelp, kVals[1]);
+    DES.computeDerivatives(tMid, kHelp, kVals[1]);
     Mathematics.svMult(h, kVals[1], kVals[1]);
-    // k2
+
+    // k2 = h * f(t + h/2, y + k1/2)
     Mathematics.svvAddScaled(0.5, kVals[1], yTemp, kHelp);
-    DES.computeDerivatives(t + h / 2, kHelp, kVals[2]);
+    DES.computeDerivatives(tMid, kHelp, kVals[2]);
     Mathematics.svMult(h, kVals[2], kVals[2]);
-    // k3
+
+    // k3 = h * f(t + h, y + k2)
     Mathematics.vvAdd(yTemp, kVals[2], kHelp);
-    DES.computeDerivatives(t + h, kHelp, kVals[3]);
+    DES.computeDerivatives(tEnd, kHelp, kVals[3]);
     Mathematics.svMult(h, kVals[3], kVals[3]);
+
     // combining all k's
-    Mathematics.svvAddScaled(2, kVals[2], kVals[3], kVals[3]);
-    Mathematics.svvAddScaled(2, kVals[1], kVals[3], kVals[2]);
-    Mathematics.svvAddAndScale(1d / 6d, kVals[0], kVals[2], change);
+    for (int i = 0; i < dim; i++) {
+      change[i] = (kVals[0][i] + (2 * (kVals[1][i] + kVals[2][i])) + kVals[3][i]) / 6d;
+    }
     return change;
+    
   }
 
   /* (non-Javadoc)

--- a/src/main/java/org/simulator/math/odes/RungeKutta_EventSolver.java
+++ b/src/main/java/org/simulator/math/odes/RungeKutta_EventSolver.java
@@ -27,6 +27,7 @@ package org.simulator.math.odes;
 import org.apache.commons.math.ode.DerivativeException;
 import org.simulator.math.Mathematics;
 import java.util.logging.Logger;
+import java.util.Arrays;
 import java.util.logging.Level;
 
 /**
@@ -51,7 +52,7 @@ public class RungeKutta_EventSolver extends AbstractDESSolver {
   /**
    * Enum representing supported RungeKutta methods
    */
-  public enum validMethod{
+  public static enum validMethod{
     RK2,
     RK4
   }
@@ -77,6 +78,7 @@ public class RungeKutta_EventSolver extends AbstractDESSolver {
   public RungeKutta_EventSolver() {
     super();
     this.method = validMethod.RK4;
+    logger.log(Level.INFO, "No method passed. Defaulting to 'RK4'.");
   }
 
   /**
@@ -84,7 +86,7 @@ public class RungeKutta_EventSolver extends AbstractDESSolver {
    */
   public RungeKutta_EventSolver(String method) {
     super();
-    this.method = getValidMethod(method);
+    this.method = parseValidMethodOrDefault(method);
   }
 
   /**
@@ -93,6 +95,7 @@ public class RungeKutta_EventSolver extends AbstractDESSolver {
   public RungeKutta_EventSolver(double stepSize) {
     super(stepSize);
     this.method = validMethod.RK4;
+    logger.log(Level.INFO, "No method passed. Defaulting to 'RK4'.");
   }
 
   /**
@@ -101,7 +104,7 @@ public class RungeKutta_EventSolver extends AbstractDESSolver {
    */
   public RungeKutta_EventSolver(double stepSize, String method) {
     super(stepSize);
-    this.method = getValidMethod(method);
+    this.method = parseValidMethodOrDefault(method);
   }
 
   /**
@@ -112,6 +115,7 @@ public class RungeKutta_EventSolver extends AbstractDESSolver {
   public RungeKutta_EventSolver(double stepSize, boolean nonnegative) {
     super(stepSize, nonnegative);
     this.method = validMethod.RK4;
+    logger.log(Level.INFO, "No method passed. Defaulting to 'RK4'.");
   }
 
   /**
@@ -122,7 +126,7 @@ public class RungeKutta_EventSolver extends AbstractDESSolver {
    */
   public RungeKutta_EventSolver(double stepSize, boolean nonnegative, String method) {
     super(stepSize, nonnegative);
-    this.method = getValidMethod(method);
+    this.method = parseValidMethodOrDefault(method);
   }
 
   /**
@@ -138,11 +142,11 @@ public class RungeKutta_EventSolver extends AbstractDESSolver {
   /**
    * Parses the string into a validMethod enum, defaults to RK4 if invalid.
    */
-  private validMethod getValidMethod(String method) {
+  private validMethod parseValidMethodOrDefault(String method) {
     try {
       return validMethod.valueOf(method.toUpperCase());
     } catch (IllegalArgumentException | NullPointerException e) {
-      logger.log(Level.INFO, "Unsupported method: {0}. Defaulting to 'RK4'.", method);
+      logger.log(Level.WARNING, "Unsupported method: {0}. Defaulting to 'RK4'.", method);
       return validMethod.RK4;
     }
   }
@@ -163,7 +167,7 @@ public class RungeKutta_EventSolver extends AbstractDESSolver {
             return computeRK4(DES, yTemp, t, h, change);
 
           default:
-            throw new IllegalArgumentException("Unexpected method: " + method);
+            throw new IllegalArgumentException("Unexpected method: " + method + ". Supported methods are: " + Arrays.toString(validMethod.values()));
         }
     }
   

--- a/src/main/java/org/simulator/math/odes/RungeKutta_EventSolver.java
+++ b/src/main/java/org/simulator/math/odes/RungeKutta_EventSolver.java
@@ -24,13 +24,10 @@
  */
 package org.simulator.math.odes;
 
-import com.sun.org.apache.xml.internal.security.utils.UnsyncBufferedOutputStream;
 import org.apache.commons.math.ode.DerivativeException;
 import org.simulator.math.Mathematics;
 import org.simulator.math.odes.exception.UnsupportedMethodException;
-
 import java.util.logging.Logger;
-import java.util.Arrays;
 import java.util.logging.Level;
 
 /**

--- a/src/main/java/org/simulator/math/odes/exception/UnsupportedMethodException.java
+++ b/src/main/java/org/simulator/math/odes/exception/UnsupportedMethodException.java
@@ -1,7 +1,10 @@
 package org.simulator.math.odes.exception;
 
+import java.util.Arrays;
+import org.simulator.math.odes.RungeKutta_EventSolver.validMethod;
+
 public class UnsupportedMethodException extends RuntimeException {
     public UnsupportedMethodException(String method) {
-        super(String.format("Unsupported method %s, supported methods are [RK2, RK4].", method));
+        super(String.format("Unsupported method %s. Supported methods are: %s", method, Arrays.toString(validMethod.values())));
     }
 }

--- a/src/main/java/org/testsuite/SBMLTestSuiteRunnerWrapper.java
+++ b/src/main/java/org/testsuite/SBMLTestSuiteRunnerWrapper.java
@@ -6,7 +6,9 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.HashSet;
 import java.util.HashMap;
+import java.util.Set;
 import java.util.Map;
 import java.util.Properties;
 
@@ -168,19 +170,17 @@ public class SBMLTestSuiteRunnerWrapper {
           left = solution.filter(inputData.getTimePoints());
         }
 
-        // Map of variables present in the test suite results file
-        Map<String, Integer> resultColumns = new HashMap<>();
+        // Set of variables present in the test suite results file
+        Set<String> resultColumns = new HashSet<>();
         for (int i = 0; i < inputData.getColumnCount(); i++) {
-          resultColumns.put(inputData.getColumnName(i), 1);
+          resultColumns.add(inputData.getColumnName(i));
         }
 
         // Boolean array to check which variables are present in the test suite results file
         boolean[] variablesToAdd = new boolean[solution.getColumnCount()];
-        if (resultColumns.containsKey(left.getColumnName(0))) {
-          variablesToAdd[0] = true;
-        }
-        for (int i = 1; i < left.getColumnCount(); i++) {
-          if (resultColumns.containsKey(left.getColumnName(i))) {
+        
+        for (int i = 0; i < left.getColumnCount(); i++) {
+          if (resultColumns.contains(left.getColumnName(i))) {
             variablesToAdd[i] = true;
           }
         }

--- a/src/test/java/RungeKutta_EventSolverTest.java
+++ b/src/test/java/RungeKutta_EventSolverTest.java
@@ -1,0 +1,119 @@
+import org.simulator.math.odes.RungeKutta_EventSolver;
+import org.simulator.math.odes.DESystem;
+import org.junit.jupiter.api.Test;
+import org.apache.commons.math.ode.DerivativeException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RungeKutta_EventSolverTest {
+
+    @Test
+    public void testComputeRK2_ExponentialDecay() throws DerivativeException {
+
+        // A system where dy/dt = -y
+        DESystem exponentialDecaySystem = new DESystem() {
+
+            public int getDimension() { 
+                return 1; 
+            }
+
+            public void computeDerivatives(double t, double[] y, double[] yDot) {
+                yDot[0] = -y[0];
+            }
+
+            @Override
+            public String[] getIdentifiers() {
+                // TODO Auto-generated method stub
+                throw new UnsupportedOperationException("Unimplemented method 'getIdentifiers'");
+            }
+
+            @Override
+            public boolean containsEventsOrRules() {
+                // TODO Auto-generated method stub
+                throw new UnsupportedOperationException("Unimplemented method 'containsEventsOrRules'");
+            }
+
+            @Override
+            public int getPositiveValueCount() {
+                // TODO Auto-generated method stub
+                throw new UnsupportedOperationException("Unimplemented method 'getPositiveValueCount'");
+            }
+
+            @Override
+            public void setDelaysIncluded(boolean delaysIncluded) {
+                // TODO Auto-generated method stub
+                throw new UnsupportedOperationException("Unimplemented method 'setDelaysIncluded'");
+            }
+        };
+
+        RungeKutta_EventSolver solver = new RungeKutta_EventSolver("RK2");
+        double[] yTemp = {1.0}; // initial value y(0) = 1
+        double t = 0.0;
+        double h = 0.1;
+        double[] change = new double[1];
+
+        double[] result = solver.computeRK2(exponentialDecaySystem, yTemp, t, h, change);
+
+        // RK2 (Heun's method) estimate:
+        // k0 = h * f(t, yTemp)
+        // k0 = h * -1 = -0.1
+        // y_temp + k0 = 0.9
+        // k1 = h * f(t + h, yTemp + k0)
+        // k1 = h * -0.9 = -0.09
+        // RK2: change = 0.5 * (k0 + k1) = 0.5 * (-0.1 -0.09) = -0.095
+        double expectedChange = -0.095;
+
+        assertEquals(expectedChange, result[0], 1e-12);
+    }
+
+    @Test
+    public void testComputeRK2_ZeroDerivative() throws DerivativeException {
+
+        // A system where dy/dt = 0
+        DESystem zeroSystem = new DESystem() {
+
+            public int getDimension() {
+                return 1; 
+            }
+
+            public void computeDerivatives(double t, double[] y, double[] yDot) {
+                yDot[0] = 0.0;
+            }
+
+            @Override
+            public String[] getIdentifiers() {
+                // TODO Auto-generated method stub
+                throw new UnsupportedOperationException("Unimplemented method 'getIdentifiers'");
+            }
+
+            @Override
+            public boolean containsEventsOrRules() {
+                // TODO Auto-generated method stub
+                throw new UnsupportedOperationException("Unimplemented method 'containsEventsOrRules'");
+            }
+
+            @Override
+            public int getPositiveValueCount() {
+                // TODO Auto-generated method stub
+                throw new UnsupportedOperationException("Unimplemented method 'getPositiveValueCount'");
+            }
+
+            @Override
+            public void setDelaysIncluded(boolean delaysIncluded) {
+                // TODO Auto-generated method stub
+                throw new UnsupportedOperationException("Unimplemented method 'setDelaysIncluded'");
+            }
+        };
+
+        RungeKutta_EventSolver solver = new RungeKutta_EventSolver("RK2");
+        double[] yTemp = {42.0}; // random value
+        double t = 0.0;
+        double h = 0.1;
+        double[] change = new double[1];
+
+        double[] result = solver.computeRK2(zeroSystem, yTemp, t, h, change);
+
+        assertEquals(0.0, result[0], 1e-12);
+    }
+}
+

--- a/src/test/java/RungeKutta_EventSolverTest.java
+++ b/src/test/java/RungeKutta_EventSolverTest.java
@@ -115,5 +115,119 @@ public class RungeKutta_EventSolverTest {
 
         assertEquals(0.0, result[0], 1e-12);
     }
+
+    @Test
+    public void testComputeRK2_InvalidDimensionMismatch() {
+        DESystem system = new DESystem() {
+            public int getDimension() {
+                return 2;
+            }
+
+            public void computeDerivatives(double t, double[] y, double[] yDot) {
+                yDot[0] = y[0];
+                yDot[1] = y[1];
+            }
+
+            @Override
+            public String[] getIdentifiers() {
+                // TODO Auto-generated method stub
+                throw new UnsupportedOperationException("Unimplemented method 'getIdentifiers'");
+            }
+
+            @Override
+            public boolean containsEventsOrRules() {
+                // TODO Auto-generated method stub
+                throw new UnsupportedOperationException("Unimplemented method 'containsEventsOrRules'");
+            }
+
+            @Override
+            public int getPositiveValueCount() {
+                // TODO Auto-generated method stub
+                throw new UnsupportedOperationException("Unimplemented method 'getPositiveValueCount'");
+            }
+
+            @Override
+            public void setDelaysIncluded(boolean delaysIncluded) {
+                // TODO Auto-generated method stub
+                throw new UnsupportedOperationException("Unimplemented method 'setDelaysIncluded'");
+            }
+        };
+
+        RungeKutta_EventSolver solver = new RungeKutta_EventSolver("RK2");
+        double[] yTemp = {1.0};  // Mismatch: only 1 element
+        double[] change = new double[2];  // Proper size here
+
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> {
+            solver.computeRK2(system, yTemp, 0.0, 0.1, change);
+        });
+    }
+
+    @Test
+    public void testComputeRK2_NullSystem() {
+        RungeKutta_EventSolver solver = new RungeKutta_EventSolver("RK2");
+
+        double[] yTemp = {1.0};
+        double[] change = new double[1];
+
+        assertThrows(NullPointerException.class, () -> {
+            solver.computeRK2(null, yTemp, 0.0, 0.1, change);
+        });
+    }
+
+    @Test
+    public void testComputeRK2_ExponentialDecay_FailsOnWrongValue() throws DerivativeException {
+        DESystem exponentialDecaySystem = new DESystem() {
+            public int getDimension() {
+                return 1;
+            }
+
+            public void computeDerivatives(double t, double[] y, double[] yDot) {
+                yDot[0] = -y[0];
+            }
+
+            @Override
+            public String[] getIdentifiers() {
+                // TODO Auto-generated method stub
+                throw new UnsupportedOperationException("Unimplemented method 'getIdentifiers'");
+            }
+
+            @Override
+            public boolean containsEventsOrRules() {
+                // TODO Auto-generated method stub
+                throw new UnsupportedOperationException("Unimplemented method 'containsEventsOrRules'");
+            }
+
+            @Override
+            public int getPositiveValueCount() {
+                // TODO Auto-generated method stub
+                throw new UnsupportedOperationException("Unimplemented method 'getPositiveValueCount'");
+            }
+
+            @Override
+            public void setDelaysIncluded(boolean delaysIncluded) {
+                // TODO Auto-generated method stub
+                throw new UnsupportedOperationException("Unimplemented method 'setDelaysIncluded'");
+            }
+        };
+
+        RungeKutta_EventSolver solver = new RungeKutta_EventSolver("RK2");
+        double[] yTemp = {1.0};
+        double t = 0.0;
+        double h = 0.1;
+        double[] change = new double[1];
+
+        solver.computeRK2(exponentialDecaySystem, yTemp, t, h, change);
+
+        // Suppose someone writes wrong test assuming change to be -0.1, actual change = -0.095
+        assertNotEquals(-0.1, change[0], 1e-12);
+    }
+
+    @Test
+    public void testDefaultsToRK4() {
+        RungeKutta_EventSolver solver = new RungeKutta_EventSolver();
+
+        assertEquals("Runge-Kutta event solver (RK4)", solver.getName());
+    }
+
 }
 


### PR DESCRIPTION
### Added Support for RK2 (Heun’s Method)
The library previously lacked RK2 support. While RK4 is more accurate, RK2 provides a useful alternative with fewer computations.
- **Implemented RK2 method using Heun’s method**.
- **User can select between RK2 and RK4 by passing an additional method argument**
- **RK4 remains the default method**.

### Minor improvements in RK4 Solver
- **Precomputed `tMid`** .
- **Optimized `svvAddScaled` calls**: Instead of multiple calls, the final sum is now computed in a single loop.

### Improvements in `SBMLTestSuiteRunnerWrapper.java`
- **Optimized `resultColumns`**: Replaced `HashMap` with `HashSet` as it is only used for checking value presence, reducing memory overhead.
- **Removed redundant condition**: Eliminated an unnecessary `if` condition in the `variablesToAdd` array.

### TODO
- Update documentation for `RungeKutta_EventSolver`.
