### PR TITLE
Update LSODAIntegrator, LSODAStepper and LSODAContext, fixing minor issues

### DIFF
--- a/src/main/java/org/simulator/math/odes/LSODA/LSODACommon.java
+++ b/src/main/java/org/simulator/math/odes/LSODA/LSODACommon.java
@@ -46,7 +46,7 @@ public class LSODACommon {
     }
 
     // SM1 array, implementation from common.c
-    private static double[] SM1 = {
+    private static final double[] SM1 = {
         0.0d, 0.5d, 0.575d, 0.55d, 0.45d, 0.35d, 0.25d, 0.2d, 0.15d, 0.1d, 0.075d, 0.05d, 0.025d
     };
 
@@ -74,10 +74,6 @@ public class LSODACommon {
 
     public double[] getSM1() {
         return SM1;
-    }
-
-    public void setSM1(double[] SM1) {
-        this.SM1 = SM1;
     }
 
     public double[][] getYh() {

--- a/src/main/java/org/simulator/math/odes/LSODA/LSODACommon.java
+++ b/src/main/java/org/simulator/math/odes/LSODA/LSODACommon.java
@@ -1,5 +1,7 @@
 package org.simulator.math.odes.LSODA;
 
+import java.util.Arrays;
+
 public class LSODACommon {
     
     public final double ETA = 2.2204460492503131e-16;
@@ -73,7 +75,7 @@ public class LSODACommon {
     }
 
     public double[] getSM1() {
-        return SM1;
+        return Arrays.copyOf(SM1, SM1.length);
     }
 
     public double[][] getYh() {

--- a/src/main/java/org/simulator/math/odes/LSODA/LSODAContext.java
+++ b/src/main/java/org/simulator/math/odes/LSODA/LSODAContext.java
@@ -2,9 +2,11 @@ package org.simulator.math.odes.LSODA;
 
 import java.util.Objects;
 
+import org.simulator.math.odes.DESystem;
+
 public class LSODAContext {
 
-    private LSODAFunction function; // what is this supposed to be?
+    private DESystem odeSystem;
     private Object data;
     private int state;
     private int neq;
@@ -16,7 +18,6 @@ public class LSODAContext {
     public LSODAContext(LSODACommon common, LSODAOptions opt) {
         this.common = common;
         this.opt = opt;
-        this.function = new LSODAFunction();
     }
 
     public LSODAContext(LSODAContext ctx, LSODACommon common) {
@@ -58,12 +59,12 @@ public class LSODAContext {
         this.common = common;
     }
 
-    public LSODAFunction getFunction() {
-        return function;
+    public DESystem getOdeSystem() {
+        return odeSystem;
     }
     
-    public void setFunction(LSODAFunction function) {
-        this.function = function;
+    public void setFunction(DESystem odeSystem) {
+        this.odeSystem= odeSystem;
     }
 
     public Object getData() {

--- a/src/main/java/org/simulator/math/odes/LSODA/LSODAContext.java
+++ b/src/main/java/org/simulator/math/odes/LSODA/LSODAContext.java
@@ -63,7 +63,7 @@ public class LSODAContext {
         return odeSystem;
     }
     
-    public void setFunction(DESystem odeSystem) {
+    public void setOdeSystem(DESystem odeSystem) {
         this.odeSystem= odeSystem;
     }
 

--- a/src/main/java/org/simulator/math/odes/LSODA/LSODAContext.java
+++ b/src/main/java/org/simulator/math/odes/LSODA/LSODAContext.java
@@ -20,6 +20,12 @@ public class LSODAContext {
         this.opt = opt;
     }
 
+    public LSODAContext(LSODACommon common, LSODAOptions opt, DESystem odeSystem) {
+        this.common = common;
+        this.opt = opt;
+        this.odeSystem = odeSystem;
+    }
+
     public LSODAContext(LSODAContext ctx, LSODACommon common) {
         this.state = ctx.state;
         this.neq = ctx.neq;

--- a/src/main/java/org/simulator/math/odes/LSODA/LSODAIntegrator.java
+++ b/src/main/java/org/simulator/math/odes/LSODA/LSODAIntegrator.java
@@ -592,10 +592,12 @@ public class LSODAIntegrator extends AdaptiveStepsizeIntegrator {
                 common.setSavf(savf);
 
                 del[0] = vmnorm(neq, y, common.getEwt());
+                double[] acor = common.getAcor();
                 for (i = 1; i <= neq; i++) {
                     y[i] = common.getYh()[1][i] + common.getEl()[1] * common.getSavf()[i];
+                    acor[i] = common.getSavf()[i];
                 }
-                common.setAcor(common.getSavf());
+                common.setAcor(acor);
             }
             else {
                 for (i = 1; i <= neq; i++) {
@@ -1100,7 +1102,7 @@ public class LSODAIntegrator extends AdaptiveStepsizeIntegrator {
 
 
             
-            if (a[j][k] == 0d) {
+            if (a[k][j] == 0d) {
                 info[0] = k;
                 continue;
             }
@@ -1118,14 +1120,12 @@ public class LSODAIntegrator extends AdaptiveStepsizeIntegrator {
             double[] temp2 = Arrays.copyOfRange(a[k], k, n+1);
             dscal(n-k, t, 1, temp2);
 
-            for(int it = k; it <= n+1; it++){
-                a[k][it] = temp2[it - k];
-            }
+            System.arraycopy(temp2, 1, a[k], k + 1, n - k);
             
             for (i = k + 1; i <= n; i++) {
-                t = a[i][k];
+                t = a[i][j];
                 if (j != k) {
-                    a[i][j] = a [i][k];
+                    a[i][j] = a[i][k];
                     a[i][k] = t;
                 }
                 
@@ -1133,9 +1133,7 @@ public class LSODAIntegrator extends AdaptiveStepsizeIntegrator {
                 double[] temp4 = Arrays.copyOfRange(a[i], k, n+1);
                 daxpy(n - k, t, temp3, 1, 1, temp4);
 
-                for(int it = k; it<= n+1; it++){
-                    a[i][it] = temp4[it - k];
-                }
+                System.arraycopy(temp4, 1, a[i], k + 1, n - k);
             }
 
         }

--- a/src/main/java/org/simulator/math/odes/LSODA/LSODAStepper.java
+++ b/src/main/java/org/simulator/math/odes/LSODA/LSODAStepper.java
@@ -12,7 +12,7 @@ public class LSODAStepper {
     }
 
     private void endStoda() {
-        double r = 1d / common.getTesco()[ctx.getNeq()][1];
+        double r = 1d / common.getTesco()[ctx.getNeq()][2];
         double[] acor = common.getAcor();
 
         for (int i = 1; i <= ctx.getNeq(); i++) {

--- a/src/test/java/LSODAIntegratorTest.java
+++ b/src/test/java/LSODAIntegratorTest.java
@@ -711,6 +711,73 @@ public class LSODAIntegratorTest {
     }
 
     @Test
+    void prjaTwoLengthSystem() throws DerivativeException {
+        ctx.setNeq(2);
+        common.setMiter(2);
+
+        DESystem system = new DESystem() {
+
+            @Override
+            public int getDimension() {
+                return 2;
+            }
+
+            @Override
+            public void computeDerivatives(double t, double[] y, double[] yDot) throws DerivativeException {
+                yDot[0] = 1;
+                yDot[1] = y[0] + y[1];
+            }
+
+            @Override
+            public String[] getIdentifiers() {
+                throw new UnsupportedOperationException("Unimplemented method 'getIdentifiers'");
+            }
+
+            @Override
+            public boolean containsEventsOrRules() {
+                throw new UnsupportedOperationException("Unimplemented method 'containsEventsOrRules'");
+            }
+
+            @Override
+            public int getPositiveValueCount() {
+                throw new UnsupportedOperationException("Unimplemented method 'getPositiveValueCount'");
+            }
+
+            @Override
+            public void setDelaysIncluded(boolean delaysIncluded) {
+                throw new UnsupportedOperationException("Unimplemented method 'setDelaysIncluded'");
+            }
+            
+        };
+
+        ctx.setOdeSystem(system);
+        common.setMiter(2);
+        common.setH(0.1);
+        double[] newEl = new double[]{0d, 1d};
+        common.setEl(newEl);
+        double[] newEwt = new double[]{0d, 1d, 1d};
+        common.setEwt(newEwt);
+        double[] newSavf = new double[]{0d, 1d, 5d}; // f(t, y0) = 1, f(t, y1) = y0 + y1;
+        common.setSavf(newSavf);
+        double[][] newWm = new double[3][3];
+        common.setWm(newWm);
+        double[] newAcor = new double[3];
+        common.setAcor(newAcor);
+        common.setTn(0d);
+        common.setNje(0);
+        common.setNfe(0);
+        int[] newIpvt = new int[3];
+        common.setIpvt(newIpvt);
+
+        double[] y = {0d, 3d, 2d};
+        int result = LSODAIntegrator.prja(ctx, y);
+
+        assertEquals(1, common.getNje());
+        assertEquals(2, common.getNfe());
+        assertEquals(1, result);
+    }
+
+    @Test
     void prjaAllZero() throws DerivativeException {
         ctx.setNeq(3);
 
@@ -871,7 +938,7 @@ public class LSODAIntegratorTest {
         double[] dy = {0d, 4d, 5d, 6d};
         int incx = 1, incy = 1;
 
-        LSODAIntegrator.daxpy(n, da, dx, incx, incy, dy);
+        LSODAIntegrator.daxpy(n, da, dx, incx, dy, incy, 1, 1);
 
         double[] expectedDy = {0d, 6d, 9d, 12d};
         assertArrayEquals(expectedDy, dy, 1e-6);
@@ -885,7 +952,7 @@ public class LSODAIntegratorTest {
         double[] dy = {0d, 4d, 5d, 6d};
         int incx = 1, incy = 1;
 
-        LSODAIntegrator.daxpy(n, da, dx, incx, incy, dy);
+        LSODAIntegrator.daxpy(n, da, dx, incx, dy, incy, 1, 1);
 
         double[] expectedDy = {0d, 4d, 5d, 6d};
         assertArrayEquals(expectedDy, dy, 1e-6);
@@ -899,7 +966,7 @@ public class LSODAIntegratorTest {
         double[] dy = {0d, 4d, 5d, 6d};
         int incx = 1, incy = 1;
 
-        LSODAIntegrator.daxpy(n, da, dx, incx, incy, dy);
+        LSODAIntegrator.daxpy(n, da, dx, incx, dy, incy, 1, 1);
 
         double[] expectedDy = {0d, 4d, 5d, 6d};
         assertArrayEquals(expectedDy, dy, 1e-6);
@@ -913,7 +980,7 @@ public class LSODAIntegratorTest {
         double[] dy = {0d, 5d, 6d, 7d, 8d};
         int incx = 2, incy = 1;
 
-        LSODAIntegrator.daxpy(n, da, dx, incx, incy, dy);
+        LSODAIntegrator.daxpy(n, da, dx, incx, dy, incy, 1, 1);
 
         double[] expectedDy = {0d, 8d, 15d, 7d, 8d};
         assertArrayEquals(expectedDy, dy, 1e-6);
@@ -927,7 +994,7 @@ public class LSODAIntegratorTest {
         double[] dy = {0d, 6d, 5d, 4d};
         int incx = -1, incy = -1;
 
-        LSODAIntegrator.daxpy(n, da, dx, incx, incy, dy);
+        LSODAIntegrator.daxpy(n, da, dx, incx, dy, incy, 1, 1);
 
         double[] expectedDy = {0d, 12d, 9d, 6d};
         assertArrayEquals(expectedDy, dy, 1e-6);
@@ -941,7 +1008,7 @@ public class LSODAIntegratorTest {
         double[] dy = {0d, 4d, 5d, 6d};
         int incx = 1, incy = 1;
 
-        LSODAIntegrator.daxpy(n, da, dx, incx, incy, dy);
+        LSODAIntegrator.daxpy(n, da, dx, incx, dy, incy, 1, 1);
 
         double[] expectedDy = {0d, 4d, 5d, 6d};
         assertArrayEquals(expectedDy, dy, 1e-6);
@@ -970,7 +1037,7 @@ public class LSODAIntegratorTest {
         double[] dy = {0d, 1e9d, 2e9d, -3e9d};
         int incx = 1, incy = 1;
 
-        LSODAIntegrator.daxpy(n, da, dx, incx, incy, dy);
+        LSODAIntegrator.daxpy(n, da, dx, incx, dy, incy, 1, 1);
 
         double[] expectedDy = {0d, 1.000000001e18, -1.999999998e18, 2.999999997e18};
         assertArrayEquals(expectedDy, dy, 1e-6);
@@ -984,7 +1051,7 @@ public class LSODAIntegratorTest {
         double[] dy = dx.clone();
         int incx = 1, incy = 1;
 
-        LSODAIntegrator.daxpy(n, da, dx, incx, incy, dy);
+        LSODAIntegrator.daxpy(n, da, dx, incx, dy, incy, 1, 1);
 
         double[] expectedDy = {0d, 3d, 6d, 9d};
         assertArrayEquals(expectedDy, dy, 1e-6);


### PR DESCRIPTION
### Minor Fixes and Refactoring in `LSODAIntegrator` and `LSODAStepper`

This PR includes a series of minor fixes, refactorings, and improvements aimed at enhancing clarity, correctness, and maintainability across the LSODA integration logic. These fixes primarily involves aligning the behavior of translated functions with the original logic and addressing subtle bugs or inconsistencies.

#### Functions Reviewed and Refactored
- In first commit:  
  `ddot`, `daxpy`, `dscal`, `idamax`, `vmnorm`, `dgefa`, `dgesl`, `ewset`, `fnorm`, `intdy`, `scaleh`, `solsy`, `corfailure`
- In second commit:  
  `correction`, `prja`, `endStoda`, `resetCoeff`, `stoda`, `cfode`

#### Structural Changes
- **Replaced `LSODAFunction` with SBSCL’s `DESystem`:**  
  This substitution improves code readability and better aligns the solver with SBSCL's architecture. It is also expected to simplify the upcoming integration mechanism by leveraging existing, well-integrated interfaces.

#### Pointer Emulation in Java
To accurately replicate the behavior of pointer-based array manipulation (used in the original Fortran/C code), I introduced temporary arrays where necessary.

#### Unit Testing
- Refactored and extended the existing unit tests in `LSODAIntegratorTest`.
- The test suite now includes **112 passing tests**, covering a wide range of solver logic.

#### Additional Context
- **Reference:**  
  [liblsoda (C version)](https://github.com/sdwfrost/liblsoda/tree/master/src)
- **Detailed explanation on my blog:**  
  [Week 1 — Coding Period Begins](https://gsoc25-baranwalayush.blogspot.com/2025/06/week-1-coding-period-begins.html)