### PR TITLE
Implementing methodSwitch and OrderSwitch with testing and integration

### DIFF
--- a/src/main/java/org/simulator/math/odes/LSODA/LSODAIntegrator.java
+++ b/src/main/java/org/simulator/math/odes/LSODA/LSODAIntegrator.java
@@ -1341,9 +1341,10 @@ public class LSODAIntegrator extends AdaptiveStepsizeIntegrator {
 
                 // switch only when new stepsize factor is more than ratio = 5 times the previous stepsize factor
                 if(rh2 < (common.RATIO * rh1) ) {
-                    logger.log(Level.INFO, "No switching " + rh1 + " " + rh2);
+                    // logger.log(Level.INFO, "No switching: rh1 = " + rh1 + ", rh2 = " + rh2);
                     return;
                 }
+                // logger.log(Level.INFO, "Switching to BDF: rh1 = " + rh1 + ", rh2 = " + rh2);
             }
 
             // method switch test passed. Reset relevant quantities for BDF
@@ -1385,6 +1386,7 @@ public class LSODAIntegrator extends AdaptiveStepsizeIntegrator {
 
         // switch only when new stepsize factor is more than previous stepsize factor
         if((rh1 * common.RATIO) < (5d * rh2)) {
+            // logger.log(Level.INFO, "No Switching: rh1 = " + rh1 + ", rh2 = " + rh2);
             return;
         }
 
@@ -1394,6 +1396,8 @@ public class LSODAIntegrator extends AdaptiveStepsizeIntegrator {
             return;
         }
 
+        // logger.log(Level.INFO, "Switching to Adams: rh1 = " + rh1 + ", rh2 = " + rh2);
+            
         // method switch test passed. Reset relevant quantities for Adams
         rh[0] = rh1;
         common.setIcount(20);
@@ -1413,9 +1417,9 @@ public class LSODAIntegrator extends AdaptiveStepsizeIntegrator {
      * </p>
      * <p>
      * It computes three candidate step-size factors:
-     *       <code>rhdn</code> : for decreasing order (nq - 1)
-     *       <code>rhsm</code> : for keeping the same order (nq)
-     *       <code>rhup</code> : for increasing order (nq + 1)
+     *       <ul><li><code>rhdn</code> : for decreasing order (nq - 1)</li>
+     *       <li><code>rhsm</code> : for keeping the same order (nq)</li>
+     *       <li><code>rhup</code> : for increasing order (nq + 1)</li></ul>
      * and then chooses the order yielding the largest stable step size.
      * If order is increased, the corresponding additional backward difference
      *      <code>yh[nq+1]</code> is computed using the most recent corrector vector, <code>acor</code>.
@@ -1462,7 +1466,7 @@ public class LSODAIntegrator extends AdaptiveStepsizeIntegrator {
             }
             common.setPdest(0d);;
         }
-
+        // logger.log(Level.INFO, "rhsm = " + rhsm + " rhdn = " + rhdn + " rhup = " + rhup);
         if(rhsm >= rhup) {
             if(rhsm >= rhdn) {                  // stay at same order
                 newq = common.getNq();

--- a/src/main/java/org/simulator/math/odes/LSODA/LSODAIntegrator.java
+++ b/src/main/java/org/simulator/math/odes/LSODA/LSODAIntegrator.java
@@ -1,5 +1,7 @@
 package org.simulator.math.odes.LSODA;
 import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.apache.commons.math.ode.DerivativeException;
 import org.simulator.math.odes.AbstractDESSolver;
@@ -8,6 +10,11 @@ import org.simulator.math.odes.DESystem;
 
 public class LSODAIntegrator extends AdaptiveStepsizeIntegrator {
     
+    /**
+     * Logger for this class
+     */
+    private static final Logger logger = Logger.getLogger(LSODAIntegrator.class.getName());
+
     public static LSODAContext ctx;
     private int neq;
     private double[] yh;
@@ -1304,6 +1311,7 @@ public class LSODAIntegrator extends AdaptiveStepsizeIntegrator {
                 nqm2 = (int) common.min(common.getNq(), mxords);
             }
             else {
+                
                 // compute ideal stepsize factor for Adams method, rh1
                 exsm = 1d / (double) (common.getNq() + 1);
                 rh1 = 1d / (1.2 * Math.pow(dsm, exsm) + 0.0000012d);
@@ -1333,6 +1341,7 @@ public class LSODAIntegrator extends AdaptiveStepsizeIntegrator {
 
                 // switch only when new stepsize factor is more than ratio = 5 times the previous stepsize factor
                 if(rh2 < (common.RATIO * rh1) ) {
+                    logger.log(Level.INFO, "No switching " + rh1 + " " + rh2);
                     return;
                 }
             }

--- a/src/main/java/org/simulator/math/odes/LSODA/LSODAStepper.java
+++ b/src/main/java/org/simulator/math/odes/LSODA/LSODAStepper.java
@@ -41,7 +41,7 @@ public class LSODAStepper {
         int[] m = new int[1];
         double[] del = new double[1];
         double[] delp = new double[1];
-        double rh = 1d;
+        double[] rh = {1d};
         double dsm, dup, exup, r, told;
         double pnorm;
 
@@ -94,17 +94,17 @@ public class LSODAStepper {
                 resetCoeff();
             }
             if (common.getH() != common.getHold()) {
-                rh = common.getH() / common.getHold();
+                rh[0] = common.getH() / common.getHold();
                 common.setH(common.getHold());
-                LSODAIntegrator.scaleh(ctx, rh);
+                LSODAIntegrator.scaleh(ctx, rh[0]);
             }
         }
 
         if (jstart == -2) {
             if (common.getH() != common.getHold()) {
-                rh = common.getH() / common.getHold();
+                rh[0] = common.getH() / common.getHold();
                 common.setH(common.getHold());
-                LSODAIntegrator.scaleh(ctx, rh);
+                LSODAIntegrator.scaleh(ctx, rh[0]);
             }
         }
 
@@ -139,8 +139,8 @@ public class LSODAStepper {
                     break;
                 }
                 if (corflag == 1) {
-                    rh = Math.max(0.25, hmin / Math.abs(common.getH()));
-                    LSODAIntegrator.scaleh(ctx, rh);
+                    rh[0] = Math.max(0.25, hmin / Math.abs(common.getH()));
+                    LSODAIntegrator.scaleh(ctx, rh[0]);
                     continue;
                 }
                 if (corflag == 2) {
@@ -173,10 +173,10 @@ public class LSODAStepper {
                 }
                 common.setIcount(common.getIcount() - 1);
                 if (common.getIcount() < 0) {
-                    // methodswitch(ctx, dsm, pnorm, &rh);
+                    LSODAIntegrator.methodSwitch(ctx, dsm, pnorm, rh);
                     if (common.getMeth() != common.getMused()) {
-                        rh = Math.max(rh, hmin / Math.abs(common.getH()));
-                        LSODAIntegrator.scaleh(ctx, rh);
+                        rh[0] = Math.max(rh[0], hmin / Math.abs(common.getH()));
+                        LSODAIntegrator.scaleh(ctx, rh[0]);
                         common.setRmax(10d);
                         endStoda();
                         break;
@@ -203,8 +203,8 @@ public class LSODAStepper {
                     }
 
                     if (orderflag == 1) {
-                        rh = Math.max(rh, hmin / Math.abs(common.getH()));
-                        LSODAIntegrator.scaleh(ctx, rh);
+                        rh[0] = Math.max(rh[0], hmin / Math.abs(common.getH()));
+                        LSODAIntegrator.scaleh(ctx, rh[0]);
                         common.setRmax(10d);
                         endStoda();
                         break;
@@ -212,8 +212,8 @@ public class LSODAStepper {
 
                     if (orderflag == 2) {
                         resetCoeff();
-                        rh = Math.max(rh, (hmin / Math.abs(common.getH())));
-                        LSODAIntegrator.scaleh(ctx, rh);
+                        rh[0] = Math.max(rh[0], (hmin / Math.abs(common.getH())));
+                        LSODAIntegrator.scaleh(ctx, rh[0]);
                         common.setRmax(10d);
                         endStoda();
                         break;
@@ -252,18 +252,18 @@ public class LSODAStepper {
                     break;
                 }
                 if (kflag > -3) {
-                    int orderflag = 0; //should be: orderswitch(ctx, 0d, dsm, &rh, kflag, maxord);
+                    int orderflag = LSODAIntegrator.orderSwitch(ctx, 0d, dsm, rh, kflag, maxord);
                     if (orderflag == 1 || orderflag == 0) {
                         if (orderflag == 0) {
-                            rh = Math.min(rh, 0.2d);
+                            rh[0] = Math.min(rh[0], 0.2d);
                         }
-                        rh = Math.max(rh, (hmin / Math.abs(common.getH())));
-                        LSODAIntegrator.scaleh(ctx, rh);
+                        rh[0] = Math.max(rh[0], (hmin / Math.abs(common.getH())));
+                        LSODAIntegrator.scaleh(ctx, rh[0]);
                     }
                     if (orderflag == 2) {
                         resetCoeff();
-                        rh = Math.max(rh, (hmin / Math.abs(common.getH())));
-                        LSODAIntegrator.scaleh(ctx, rh);
+                        rh[0] = Math.max(rh[0], (hmin / Math.abs(common.getH())));
+                        LSODAIntegrator.scaleh(ctx, rh[0]);
                     }
                     continue;
                 }
@@ -274,9 +274,9 @@ public class LSODAStepper {
                         jstart = 1;
                         break;
                     } else {
-                        rh = 0.1d;
-                        rh = Math.max((hmin / Math.abs(common.getH())), rh);
-                        common.setH(common.getH() * rh);
+                        rh[0] = 0.1d;
+                        rh[0] = Math.max((hmin / Math.abs(common.getH())), rh[0]);
+                        common.setH(common.getH() * rh[0]);
                         for (int i = 1; i <= neq; i++) {
                             y[i] = common.getYh()[1][i];
                         }

--- a/src/main/java/org/simulator/math/odes/LSODA/LSODAStepper.java
+++ b/src/main/java/org/simulator/math/odes/LSODA/LSODAStepper.java
@@ -193,9 +193,9 @@ public class LSODAStepper {
                         common.setSavf(savf);
                         dup = LSODAIntegrator.vmnorm(neq, common.getSavf(), common.getEwt()) / common.getTesco()[common.getNq()][3];
                         exup = 1d / (double) ((common.getNq() + 1) + 1);
-                        rhup = 1d / (1.4 * Math.pow(dup, exup) + 0.0000014);
+                        rhup = 1d / (1.4 * Math.pow(dup, exup) + 0.0000014d);
                     }
-                    int orderflag = 0; // orderswitch(ctx, rhup, dsm, &rh, kflag, maxord);
+                    int orderflag = LSODAIntegrator.orderSwitch(ctx, rhup, dsm, rh, kflag, maxord);
 
                     if (orderflag == 0) {
                         endStoda();

--- a/src/test/java/LSODAIntegratorTest.java
+++ b/src/test/java/LSODAIntegratorTest.java
@@ -2751,6 +2751,87 @@ public class LSODAIntegratorTest {
         assertEquals(6d, y[2], 1e-10, "y[2] should be 6 after the call");
     }
 
+    /*
+     * test for methodSwitch() helper function
+     */
+    @Test
+    void methodSwitchNonstiffOrderMoreThan5() {
+        ctx.setNeq(1);
+        opt.setMxordn(12);
+        opt.setMxords(5);
+        common.setMeth(1);
+        common.setNq(7);
+        double[] rh = new double[1];
+        LSODAIntegrator.methodSwitch(ctx, 0, 0, rh);
+
+        assertEquals(1, common.getMeth());  // no change in method
+    } 
+
+    @Test
+    void methodSwitchNonstiffPollutedErrorCase1() {
+        ctx.setNeq(1);
+        opt.setMxordn(12);
+        opt.setMxords(5);
+        common.setMeth(1);
+        common.setNq(3);
+        common.setPdest(0);                     // last lipschitz estimate, pdest set to 0
+        common.setIrflag(0);                   // No stepsize stability, irflag set to 0
+        double[] rh = new double[1];
+        LSODAIntegrator.methodSwitch(ctx, 0, 0, rh);
+
+        assertEquals(1, common.getMeth());  // no change in method
+    } 
+
+    @Test
+    void methodSwitchNonstiffPollutedErrorCase2() {
+        ctx.setNeq(1);
+        opt.setMxordn(12);
+        opt.setMxords(5);
+        common.setMeth(1);
+        common.setNq(3);           
+        common.setPdest(1);    
+        common.setIrflag(0);                   // No stepsize stability, irflag set to 0
+        double[] rh = new double[1];
+        LSODAIntegrator.methodSwitch(ctx, 1e-12, 1000, rh);
+
+        assertEquals(1, common.getMeth());  // no change in method
+    } 
+
+    @Test
+    void methodSwitchNonstiffPollutedErrorCase3() {
+        ctx.setNeq(1);
+        opt.setMxordn(12);
+        opt.setMxords(3);
+        common.setMeth(1);
+        common.setNq(4);           
+        common.setPdest(0);    
+        common.setIrflag(1);   
+        double[] rh = new double[1];
+        LSODAIntegrator.methodSwitch(ctx, 1, 1, rh);
+
+        assertEquals(2, common.getMeth());  // method switched to BDF
+        assertEquals(2, rh[0]);             
+        assertEquals(3, common.getNq());    // order is minimum of mxords and current order
+    } 
+
+    @Test
+    void methodSwitchNonstiffLessStepsizeFactorGain() {
+        ctx.setNeq(1);
+        opt.setMxordn(10);
+        opt.setMxords(5);
+        common.setMeth(1);
+        common.setNq(5);           
+        common.setPdest(1);    
+        common.setIrflag(1); 
+        common.setH(0.1);
+        common.setPdlast(5);  
+        double[] rh = new double[1];
+        LSODAIntegrator.methodSwitch(ctx, 1e-2, 1, rh);
+
+        assertEquals(1, common.getMeth());  // No method switch, rh2 < rh1 * 5
+    } 
+
+
     void print2DArray(double[][]a){
         for(int i=0; i<a.length; i++){
             for(int j=0; j<a[0].length; j++){


### PR DESCRIPTION
### Implemented `methodSwitch` and `orderSwitch` in `LSODAIntegrator`

This PR introduces two new helper functions to the `LSODAIntegrator` class:

- **`methodSwitch()`**
- **`orderSwitch()`**

#### Summary of Changes
- Implemented both functions.
- Added detailed docstrings for both methods to improve readability and maintainability.
- Refactored the `stoda()` method to call these helper functions, where needed.
- Developed and added unit tests to ensure correctness and coverage for both `methodSwitch` and `orderSwitch`.

#### Reference
[libLSODA](https://github.com/libsbmlsim/liblsoda/blob/master/src/)
