### PR TITLE
Update Deepak Yadav’s LinkedIn URL in docs and POM

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -154,7 +154,7 @@
 <h2><a name="Acknowledgments"></a>Acknowledgments</h2>
 <p>Many thanks to B. Kotcon, S. Mesuro, D. Rozenfeld, A. Yodpinyanee, A. Perez, E. Doi, R. Mehlinger, S. Ehrlich, M. Hunt, G. Tucker, P. Scherpelz, A. Becker, E. Harley, and C. Moore, Harvey Mudd College, USA, for providing a Java implementation of Rosenbrock&#x2019;s method as part of the <a class="externalLink" href="http://odetoolkit.hmc.edu">ODEToolkit</a>.</p>
 <p>We like to thank <a class="externalLink" href="http://www.abi.auckland.ac.nz/uoa/mike-cooling/">Michael T. Cooling</a>, University of Auckland, New Zealand, for fruitful discussion.</p>
-<p>We thank Deepak Yadav (<a class="externalLink" href="https://www.linkedin.com/in/deepak-yadav-97aa22297/">https://www.linkedin.com/in/deepak-yadav-97aa22297/</a>) for contributing updates to the SBSCL project website and documentation.</p>
+<p>We thank Deepak Yadav (<a class="externalLink" href="https://www.linkedin.com/in/dyrpsf/">https://www.linkedin.com/in/dyrpsf/</a>) for contributing updates to the SBSCL project website and documentation.</p>
 <p>This work was funded by the Federal Ministry of Education and Research (<a class="externalLink" href="http://www.bmbf.de/en/">BMBF</a>, Germany) as part of the <a class="externalLink" href="http://www.virtual-liver.de">Virtual Liver Network</a>.</p>
 </section>
         </div>

--- a/pom.xml
+++ b/pom.xml
@@ -373,7 +373,7 @@
     <contributor>
       <name>Deepak Yadav</name>
       <email>dyrpsf@gmail.com</email>
-      <url>https://www.linkedin.com/in/deepak-yadav-97aa22297/</url>
+      <url>https://www.linkedin.com/in/dyrpsf/</url>
       <organization>VIT Bhopal University</organization>
     </contributor>
   </contributors>

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -89,6 +89,6 @@ Many thanks to B. Kotcon, S. Mesuro, D. Rozenfeld, A. Yodpinyanee, A. Perez, E. 
 
 We like to thank [Michael T. Cooling](http://www.abi.auckland.ac.nz/uoa/mike-cooling/), University of Auckland, New Zealand, for fruitful discussion.
 
-We thank [Deepak Yadav](https://www.linkedin.com/in/deepak-yadav-97aa22297/) for contributing updates to the SBSCL project website and documentation.
+We thank [Deepak Yadav](https://www.linkedin.com/in/dyrpsf/) for contributing updates to the SBSCL project website and documentation.
 
 This work was funded by the Federal Ministry of Education and Research ([BMBF](http://www.bmbf.de/en/), Germany) as part of the [Virtual Liver Network](http://www.virtual-liver.de).


### PR DESCRIPTION
This PR updates my LinkedIn profile URL to a cleaner slug in the following places:

- `pom.xml` contributor entry
- `src/site/markdown/index.md` acknowledgments
- `docs/index.html` acknowledgments

No code logic is changed; this is only a documentation/metadata update.