### PR TITLE
WIP: Scaffold Python/Docker CLI architecture for BioSimulators curation (#68)

### DIFF
--- a/biosimulators/Dockerfile
+++ b/biosimulators/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.9-slim-bullseye
+
+# Install OpenJDK 11
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends openjdk-11-jre-headless && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy and install Python dependencies
+COPY biosimulators/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the dependencies folder and the compiled Java engine
+COPY target/dependency /app/lib
+COPY target/sbscl-2.1.1.jar /app/sbscl.jar
+
+# Copy the Python CLI and Entrypoint script
+COPY biosimulators/main.py .
+COPY biosimulators/entrypoint.sh .
+
+# Make the entrypoint script executable
+RUN chmod +x /app/entrypoint.sh
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/biosimulators/entrypoint.sh
+++ b/biosimulators/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Start the Java Gateway Server in the background. 
+# We include the main jar AND all dependency jars in the classpath.
+java -cp "/app/sbscl.jar:/app/lib/*" org.simulator.biosimulators.BioSimulatorsGateway &
+
+# Give the Java server 2 seconds to initialize
+sleep 2
+
+# Execute the Python CLI, passing along any arguments provided to Docker
+python /app/main.py "$@"

--- a/biosimulators/main.py
+++ b/biosimulators/main.py
@@ -1,0 +1,27 @@
+import argparse
+from py4j.java_gateway import JavaGateway
+from biosimulators_utils.combine.exec import exec_sedml_docs_in_archive
+
+def exec_sed_doc(doc, working_dir, base_out_path, rel_out_path=None, apply_xml_model_changes=False, log=None, indent=0, out_dir=None, config=None):
+    pass
+
+def exec_sed_task(task, variables, preprocessed_task=None, log=None, config=None):
+    gateway = JavaGateway()
+    sbscl_engine = gateway.entry_point
+    return {}, log
+
+def main():
+    parser = argparse.ArgumentParser(description="SBSCL BioSimulators interface")
+    parser.add_argument("-i", "--archive", required=True, type=str)
+    parser.add_argument("-o", "--out-dir", required=True, type=str)
+    args = parser.parse_args()
+
+    exec_sedml_docs_in_archive(
+        exec_sed_doc,
+        args.archive,
+        args.out_dir,
+        apply_xml_model_changes=True,
+    )
+
+if __name__ == "__main__":
+    main()

--- a/biosimulators/requirements.txt
+++ b/biosimulators/requirements.txt
@@ -1,0 +1,3 @@
+biosimulators-utils
+py4j
+numpy

--- a/pom.xml
+++ b/pom.xml
@@ -518,6 +518,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>net.sf.py4j</groupId>
+      <artifactId>py4j</artifactId>
+      <version>0.10.9.7</version>
+    </dependency>
   </dependencies>
 
 

--- a/src/main/java/org/simulator/biosimulators/BioSimulatorsGateway.java
+++ b/src/main/java/org/simulator/biosimulators/BioSimulatorsGateway.java
@@ -1,0 +1,17 @@
+package org.simulator.biosimulators;
+
+import py4j.GatewayServer;
+
+public class BioSimulatorsGateway {
+
+    public BioSimulatorsGateway() {
+    }
+
+    public static void main(String[] args) {
+        BioSimulatorsGateway app = new BioSimulatorsGateway();
+        // Starts the server on the default port (25333)
+        GatewayServer server = new GatewayServer(app);
+        server.start();
+        System.out.println("SBSCL Gateway Server Started");
+    }
+}


### PR DESCRIPTION
## Problem
This PR addresses Issue #68, aiming to reach Level 5 curation on BioSimulators, which requires a containerized command-line interface.

## Architectural Setup
This Draft PR scaffolds the recommended architecture:
1. **Py4J Integration**: Added `py4j` to `pom.xml` and created `BioSimulatorsGateway.java` to act as the Java-side server for the SBSCL engine.
2. **Python CLI**: Created `biosimulators/main.py` utilizing `biosimulators-utils` to handle SED-ML parsing and interface with the Java Gateway.
3. **Containerization**: Created a `Dockerfile` and `entrypoint.sh` to package the Fat JAR along with its dependencies, initialize the Java server in the background, and expose the Python CLI.
4. **Tested**: Verified the Docker build and the Python entrypoint locally.

## Next Steps
- Submitting this as a WIP to get maintainer feedback on the Py4J/Docker architectural approach before fully mapping the SED-ML tasks.
- Once approved, the `main.py` script needs the specific SED-ML variables mapped to the `sbscl_engine` via the Py4J gateway.