### PR TITLE
Refactor: Migrate from JUL to SLF4J API in SBMLinterpreter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -518,6 +518,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.32</version>
+    </dependency>
   </dependencies>
 
 

--- a/src/main/java/org/simulator/sbml/SBMLinterpreter.java
+++ b/src/main/java/org/simulator/sbml/SBMLinterpreter.java
@@ -29,8 +29,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import fern.network.AmountManager;
 import org.apache.commons.math.ode.DerivativeException;
@@ -69,7 +69,7 @@ public class SBMLinterpreter extends EquationSystem {
   /**
    * A {@link Logger}.
    */
-  private static final transient Logger logger = Logger.getLogger(SBMLinterpreter.class.getName());
+  private static final transient Logger logger = LoggerFactory.getLogger(SBMLinterpreter.class);
 
   /**
    * Generated serial version UID
@@ -810,8 +810,7 @@ public class SBMLinterpreter extends EquationSystem {
         law.getMath()
             .updateVariables(); // make sure references to local parameter values are reflected in the ASTNode
       } else {
-        logger.log(Level.FINE,
-            "Cannot set local parameters for reaction {0} because of missing kinetic law.",
+        logger.debug("Cannot set local parameters for reaction {} because of missing kinetic law.", 
             model.getReaction(reactionNum).getId());
       }
     }
@@ -820,9 +819,7 @@ public class SBMLinterpreter extends EquationSystem {
         init();
       } catch (Exception exc) {
         // This can never happen
-        logger
-            .log(Level.WARNING, "Could not re-initialize the model with the new parameter values.",
-                exc);
+       logger.warn("Could not re-initialize the model with the new parameter values.", exc);
       }
     } else {
       int nCompPlusSpec = model.getCompartmentCount() + model.getSpeciesCount();


### PR DESCRIPTION
## Overview
This PR modernizes the logging framework in `SBMLinterpreter.java` by migrating from Java's built-in `java.util.logging` (JUL) to the SLF4J API. This aligns with the broader ecosystem goal of standardizing logging across the JSBML/SBSCL libraries (as discussed in JSBML Issue #217).

## Changes Made
* Replaced `java.util.logging.Logger` with `org.slf4j.Logger` and `LoggerFactory` in `SBMLinterpreter.java`.
* Updated logging syntax from `logger.log(Level, ...)` to the SLF4J standard `logger.debug()` and `logger.warn()` methods, utilizing parameterized messages `{}`.
* Added the `slf4j-api` dependency to the root `pom.xml`.

## Validation
* Compiled successfully without errors.