### PR TITLE
ci: add GitHub Actions workflow for Maven build and test

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,28 @@
+name: Maven Build & Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build and Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+          cache: 'maven'
+
+      - name: Build and Test with Maven
+        run: mvn --batch-mode clean verify

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,10 +8,13 @@ on:
     branches:
       - master
 
+permissions:
+   contents: read
+
 jobs:
   build:
     name: Build and Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Addresses #76 

- This PR introduces a GitHub Actions CI pipeline to automate maven build and test verification.
- Runs `mvn --batch-mode clean verify` on push and pull requests targeting `master`.